### PR TITLE
External loaded generators add KustTarget to PluginHelpers

### DIFF
--- a/api/internal/plugins/loader/loader.go
+++ b/api/internal/plugins/loader/loader.go
@@ -91,10 +91,10 @@ func (l *Loader) LoadGenerator(
 }
 
 func (l *Loader) LoadTransformers(
-	ldr ifc.Loader, v ifc.Validator, rm resmap.ResMap) ([]*resmap.TransformerWithProperties, error) {
+	ldr ifc.Loader, v ifc.Validator, rm resmap.ResMap, kt resmap.KustTargetInterface) ([]*resmap.TransformerWithProperties, error) {
 	var result []*resmap.TransformerWithProperties
 	for _, res := range rm.Resources() {
-		t, err := l.LoadTransformer(ldr, v, res)
+		t, err := l.LoadTransformer(ldr, v, res, kt)
 		if err != nil {
 			return nil, err
 		}
@@ -108,8 +108,8 @@ func (l *Loader) LoadTransformers(
 }
 
 func (l *Loader) LoadTransformer(
-	ldr ifc.Loader, v ifc.Validator, res *resource.Resource) (*resmap.TransformerWithProperties, error) {
-	c, err := l.loadAndConfigurePlugin(ldr, v, res, nil)
+	ldr ifc.Loader, v ifc.Validator, res *resource.Resource, kt resmap.KustTargetInterface) (*resmap.TransformerWithProperties, error) {
+	c, err := l.loadAndConfigurePlugin(ldr, v, res, kt)
 	if err != nil {
 		return nil, err
 	}

--- a/api/internal/plugins/loader/loader_test.go
+++ b/api/internal/plugins/loader/loader_test.go
@@ -73,7 +73,7 @@ func TestLoader(t *testing.T) {
 			t.Fatal("expect non-nil loader")
 		}
 		_, err = pLdr.LoadGenerators(
-			fLdr, valtest_test.MakeFakeValidator(), generatorConfigs)
+			fLdr, valtest_test.MakeFakeValidator(), generatorConfigs, nil)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/api/internal/target/kusttarget.go
+++ b/api/internal/target/kusttarget.go
@@ -376,7 +376,7 @@ func (kt *KustTarget) configureExternalTransformers(transformers []string) ([]*r
 	if err != nil {
 		return nil, err
 	}
-	return kt.pLdr.LoadTransformers(kt.ldr, kt.validator, ra.ResMap())
+	return kt.pLdr.LoadTransformers(kt.ldr, kt.validator, ra.ResMap(), kt)
 }
 
 func (kt *KustTarget) runValidators(ra *accumulator.ResAccumulator) error {

--- a/api/internal/target/kusttarget.go
+++ b/api/internal/target/kusttarget.go
@@ -329,7 +329,7 @@ func (kt *KustTarget) configureExternalGenerators() (
 	if err != nil {
 		return nil, err
 	}
-	return kt.pLdr.LoadGenerators(kt.ldr, kt.validator, ra.ResMap())
+	return kt.pLdr.LoadGenerators(kt.ldr, kt.validator, ra.ResMap(), kt)
 }
 
 func (kt *KustTarget) runTransformers(ra *accumulator.ResAccumulator) error {


### PR DESCRIPTION
Hi @koba1t, 

I was testing your [PR](https://github.com/kubernetes-sigs/kustomize/pull/5228) but had some issues when ResourceGenerator was loaded as "externalGenerator". It would result in null pointer panic because external generators do not have `kt` in PluginHelper. 

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x18 pc=0x1050f6b28]

goroutine 1 [running]:
sigs.k8s.io/kustomize/api/resmap.(*PluginHelpers).AccumulateResource(0x14000474a40, {0x14000478248, 0x7})
        /Users/lukaskugor/projects/github.com/kustomize/api/resmap/resmap.go:87 +0xe8
sigs.k8s.io/kustomize/api/internal/builtins.(*ResourceGeneratorPlugin).Generate(0x0?)
        /Users/lukaskugor/projects/github.com/kustomize/api/internal/builtins/ResourceGenerator.go:29 +0x2c
sigs.k8s.io/kustomize/api/internal/target.(*KustTarget).runGenerators(0x140000aceb0, 0x14000099f40)
        /Users/lukaskugor/projects/github.com/kustomize/api/internal/target/kusttarget.go:287 +0x20c
sigs.k8s.io/kustomize/api/internal/target.(*KustTarget).accumulateTarget(0x140000aceb0, 0x14000099f40)
        /Users/lukaskugor/projects/github.com/kustomize/api/internal/target/kusttarget.go:228 +0x240
sigs.k8s.io/kustomize/api/internal/target.(*KustTarget).AccumulateTarget(0x140000aceb0)
        /Users/lukaskugor/projects/github.com/kustomize/api/internal/target/kusttarget.go:203 +0xec
sigs.k8s.io/kustomize/api/internal/target.(*KustTarget).makeCustomizedResMap(0x140000aceb0)
        /Users/lukaskugor/projects/github.com/kustomize/api/internal/target/kusttarget.go:135 +0x68
sigs.k8s.io/kustomize/api/internal/target.(*KustTarget).MakeCustomizedResMap(...)
        /Users/lukaskugor/projects/github.com/kustomize/api/internal/target/kusttarget.go:126
sigs.k8s.io/kustomize/api/krusty.(*Kustomizer).Run(0x1400035fcc8, {0x105464f00, 0x105a5d0c8}, {0x16b37f270, 0x13})
        /Users/lukaskugor/projects/github.com/kustomize/api/krusty/kustomizer.go:91 +0x2a4
sigs.k8s.io/kustomize/kustomize/v5/commands/build.NewCmdBuild.func1(0x140000eb808, {0x14000230e70?, 0x4?, 0x105179ad4?})
        /Users/lukaskugor/projects/github.com/kustomize/kustomize/commands/build/build.go:84 +0x15c
github.com/spf13/cobra.(*Command).execute(0x140000eb808, {0x14000230e30, 0x1, 0x1})
        /Users/lukaskugor/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:940 +0x654
github.com/spf13/cobra.(*Command).ExecuteC(0x140000eb208)
        /Users/lukaskugor/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:1068 +0x320
github.com/spf13/cobra.(*Command).Execute(0x105953f28?)
        /Users/lukaskugor/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:992 +0x1c
main.main()
        /Users/lukaskugor/projects/github.com/kustomize/kustomize/main.go:14 +0x20
```


Most basic example:

```yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization

resources:
  - |-
    apiVersion: builtin
    kind: ResourceGenerator
    metadata:
      name: myMap
    resource: cm.yaml
```

Please feel free to reach out if you'd like any help with this stuff. I'm looking to use at least some portions of Composition API to test out some new Kustomize layouts for a larger repo.
